### PR TITLE
feat: add PostsWithEmbeds component

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>ATproto Viz Playground</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,23 @@
-import { ChangeEvent, useEffect, useState } from 'react'
-import AtpAgent from "@atproto/api"
-import { BlueSkySessionData } from './utils/types'
-import { Posts } from './components/PostsVisualizer';
-import { useRepo } from './hooks/get-repo';
+import { ChangeEvent, useEffect, useState } from "react";
+import AtpAgent from "@atproto/api";
+import { BlueSkySessionData } from "./utils/types";
+import { Posts } from "./components/PostsVisualizer";
+import { useRepo } from "./hooks/get-repo";
+import { PostWithEmbed } from "./components/Embeds";
 
 export interface VisualizerProps {
   session?: BlueSkySessionData;
-  agent?: AtpAgent
+  agent?: AtpAgent;
 }
 
 const Visualizer = ({ session, agent }: VisualizerProps) => {
   const [activeView, setActiveView] = useState<string>("posts");
   const did: string = session?.did || "";
-  const { repo, getRepo, loading } = useRepo({ did, agent: agent as AtpAgent })
+  const { repo, getRepo, loading } = useRepo({ did, agent: agent as AtpAgent });
+  const embedsCount =
+    repo.embeds.external?.length +
+    repo.embeds.withImages?.length +
+    repo.embeds.withQuotes?.length;
 
   useEffect(() => {
     if (session && !repo) {
@@ -38,6 +43,12 @@ const Visualizer = ({ session, agent }: VisualizerProps) => {
             className={activeView === "posts" ? "active" : ""}
           >
             Posts ({repo?.posts.length})
+          </button>
+          <button
+            onClick={() => setActiveView("embeds")}
+            className={activeView === "embeds" ? "active" : ""}
+          >
+            Embeds ({embedsCount})
           </button>
           <button
             onClick={() => setActiveView("likes")}
@@ -70,6 +81,15 @@ const Visualizer = ({ session, agent }: VisualizerProps) => {
         </div>
       )}
 
+      {!loading && activeView === "embeds" && (
+        <div className="posts-container">
+          <PostWithEmbed
+            agent={agent as AtpAgent}
+            did={session.did}
+          />
+        </div>
+      )}
+
       {!loading && activeView === "likes" && (
         <div className="likes-container">
           <p>I'll get to this soon</p>
@@ -86,28 +106,28 @@ const Visualizer = ({ session, agent }: VisualizerProps) => {
 };
 
 function App() {
-  const [handle, setHandle] = useState<string>("")
-  const [password, setPassword] = useState<string>("")
-  const [appSession, setAppSession] = useState<BlueSkySessionData>()
-  const [error, setError] = useState<string>("")
-  const [isLoading, setIsLoading] = useState<boolean>(false)
-  const [agent, setAgent] = useState<AtpAgent>()
+  const [handle, setHandle] = useState<string>("");
+  const [password, setPassword] = useState<string>("");
+  const [appSession, setAppSession] = useState<BlueSkySessionData>();
+  const [error, setError] = useState<string>("");
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [agent, setAgent] = useState<AtpAgent>();
 
   useEffect(() => {
     const newAgent = new AtpAgent({
-      service: "https://bsky.social"
-    })
-    setAgent(newAgent)
-  }, [])
+      service: "https://bsky.social",
+    });
+    setAgent(newAgent);
+  }, []);
 
   const login = async () => {
     if (!handle || !password) {
-      setError("Please enter both handle and password")
-      return
+      setError("Please enter both handle and password");
+      return;
     }
 
     if (!agent) {
-      setError("Agent is not initialized")
+      setError("Agent is not initialized");
       return;
     }
 
@@ -117,16 +137,18 @@ function App() {
 
       const result = await agent.login({
         identifier: handle,
-        password
+        password,
       });
       setAppSession(result.data as BlueSkySessionData);
     } catch (err) {
       console.error("Login error:", err);
-      setError(`Login failed: ${err instanceof Error ? err.message : String(err)}`);
+      setError(
+        `Login failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
     } finally {
       setIsLoading(false);
     }
-  }
+  };
 
   return (
     <div className="app-container">
@@ -140,29 +162,28 @@ function App() {
               />
               <p>logged in as {appSession?.handle}</p>
             </div>
-          ):
-          (
+          ) : (
             <div className="input-group">
               <input
                 type="text"
-                placeholder='Bluesky handle. e.g. kaf.bsky.social'
+                placeholder="Bluesky handle. e.g. kaf.bsky.social"
                 onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                  setHandle(e.target.value)
+                  setHandle(e.target.value);
                 }}
                 value={handle}
                 className="handle-input"
               />
               <input
                 type="password"
-                placeholder='Password'
+                placeholder="Password"
                 onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                  setPassword(e.target.value)
+                  setPassword(e.target.value);
                 }}
                 value={password}
                 className="password-input"
               />
               <button onClick={login} disabled={isLoading}>
-                {isLoading ? 'Logging in...' : 'Login'}
+                {isLoading ? "Logging in..." : "Login"}
               </button>
               {error && <div className="error-message">{error}</div>}
             </div>
@@ -173,7 +194,7 @@ function App() {
         </div>
       </div>
     </div>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/components/Embeds/embeds.css
+++ b/src/components/Embeds/embeds.css
@@ -1,0 +1,88 @@
+.atp-embed {
+    width: fit-content;
+    height: fit-content;
+    border-radius: 6px;
+    padding: 0.6em 0.6em;
+    margin: 0.6em 0;
+    border: 1px solid var(--border-color);
+
+    .atp-embed-thumbnail {
+        height: 80%;
+        width: 100%;
+        object-fit: contain;
+
+        img {
+            width: 100%;
+            height: 100%;
+            border-radius: 6px;
+        }
+    }
+
+    .atp-embed-content {
+        font-size: 14px;
+        display: flex;
+        flex-direction: column;
+        gap: 1em;
+        padding: 0.8em 0;
+
+        .atp-embed-link {
+            padding-top: 0.6em;
+            font-size: 12px;
+            color: var(--text-secondary);
+            border-top: 1px solid var(--border-color);
+        }
+
+        .atp-embed-description {
+            color: var(--text-secondary);
+        }
+    }
+}
+
+.atp-embed-title {
+    font-weight: 600;
+}
+
+.atp-embed-images {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+
+    .atp-embed-image {
+        position: relative;
+        max-width: 100%;
+    }
+
+    .atp-embed-image img {
+        max-width: 100%;
+        border-radius: 6px;
+    }
+
+    .atp-embed-image-alt {
+        font-size: 12px;
+        color: var(--text-secondary);
+        margin-top: 0.3em;
+    }
+}
+
+.atp-embed-quote {
+    padding: 0.2em;
+    border-radius: 6px;
+    width: 100%;
+
+    .atp-embed-quote-header {
+        margin-bottom: 0.5em;
+    }
+
+    .atp-embed-quote-author {
+        font-weight: 600;
+        margin-right: 0.5em;
+    }
+
+    .atp-embed-quote-handle {
+        font-size: 12px;
+        color: var(--text-secondary);
+    }
+
+    .atp-embed-quote-content {
+        font-size: 14px;
+    }
+}

--- a/src/components/Embeds/index.tsx
+++ b/src/components/Embeds/index.tsx
@@ -1,0 +1,146 @@
+import { useRepo } from "../../hooks/get-repo";
+import { PostProps } from "../PostsVisualizer";
+import "./embeds.css";
+import "../../index.css";
+import { formatDate } from "../../utils/ui";
+import { useCallback, useEffect, useState } from "react";
+import { PostView } from "@atproto/api/dist/client/types/app/bsky/feed/defs";
+
+type PostWithEmbedProps = PostProps;
+
+export const PostWithEmbed = ({
+  agent,
+  did,
+  className,
+}: PostWithEmbedProps) => {
+  const identifier = did || "";
+  const { repo } = useRepo({ agent, did: identifier });
+  const [quotedContentMap, setQuotedContentMap] = useState<Record<string, PostView>>({});
+
+  const quotedPostUris = repo.posts
+    .filter(post => post.record.embed?.$type === "app.bsky.embed.record")
+    // @ts-expect-error there should be a relationship with PostView and Post in utils/types.ts
+    // i'll address this later
+    .map(post => post?.record?.embed?.record.uri);
+
+  const getQuotedContent = useCallback(
+    async (uris: string[]) => {
+      if (uris.length === 0) return;
+
+      try {
+        const res = await agent.api.app.bsky.feed.getPosts({ uris });
+
+        const newQuotedContent = {...quotedContentMap};
+        res.data.posts.forEach(post => {
+          newQuotedContent[post.uri] = post;
+        });
+
+        setQuotedContentMap(newQuotedContent);
+      } catch (error) {
+        console.error("Error fetching quoted posts:", error);
+      }
+    },
+    [agent.api.app.bsky.feed, quotedContentMap]
+  );
+
+  useEffect(() => {
+    const urisToFetch = quotedPostUris.filter(uri => !quotedContentMap[uri]);
+    if (urisToFetch.length > 0) {
+      getQuotedContent(urisToFetch);
+    }
+  }, [quotedPostUris, getQuotedContent, quotedContentMap]);
+
+  return (
+    <>
+      {repo.posts.map((post) => {
+        const record = post.record;
+        const handle = agent.session?.handle || "";
+        const displayName = handle.split(".")[0];
+
+        const quotedPost = record.embed?.$type === "app.bsky.embed.record"
+          ? quotedContentMap[record.embed.record.uri]
+          : null;
+
+        return (
+          <div key={post.rkey} className={`atp-post-card ${className}`}>
+            <div className="atp-post-header">
+              <span className="atp-post-author">{displayName}</span>
+              <span className="atp-post-handle">@{handle}</span>
+              <span className="atp-post-date">
+                {formatDate(record.createdAt)}
+              </span>
+            </div>
+            <div className="atp-post-content">{record.text}</div>
+
+            {record.embed &&
+              record.embed.$type === "app.bsky.embed.external" && (
+                <div className="atp-embed">
+                  {record.embed.external.thumb && (
+                    <div className="atp-embed-thumbnail">
+                      <img
+                        src={`https://bsky.social/xrpc/com.atproto.sync.getBlob?did=${identifier}&cid=${record.embed.external.thumb.ref.$link}`}
+                        alt={record.embed.external.title}
+                      />
+                    </div>
+                  )}
+                  <div className="atp-embed-content">
+                    <div className="atp-embed-title">
+                      {record.embed.external.title}
+                    </div>
+                    <div className="atp-embed-description">
+                      {record.embed.external.description}
+                    </div>
+                    <div className="atp-embed-link">
+                      {new URL(record.embed.external.uri).hostname}
+                    </div>
+                  </div>
+                </div>
+              )}
+
+            {record.embed && record.embed.$type === "app.bsky.embed.images" && (
+              <div className="atp-embed">
+                <div className="atp-embed-images">
+                  {record.embed.images.map((image, index) => (
+                    <div key={index} className="atp-embed-image">
+                      <img
+                        src={`https://bsky.social/xrpc/com.atproto.sync.getBlob?did=${identifier}&cid=${image.image.ref.$link}`}
+                        alt={image.alt || "Embedded image"}
+                      />
+                      {image.alt && (
+                        <div className="atp-embed-image-alt">{image.alt}</div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {record.embed && record.embed.$type === "app.bsky.embed.record" && (
+              <div className="atp-embed">
+                <div className="atp-embed-quote">
+                  {quotedPost && (
+                    <div className="atp-embed-quote-content">
+                      <div key={quotedPost.cid}>
+                        <div className="atp-post-header">
+                          <span className="atp-post-author">
+                            {quotedPost.author.displayName}
+                          </span>
+                          <span className="atp-post-handle">
+                            @{quotedPost.author.handle}
+                          </span>
+                        </div>
+                        <div className="atp-post-content">
+                          {quotedPost.record.text as string}
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </>
+  );
+};

--- a/src/components/PostsVisualizer.tsx
+++ b/src/components/PostsVisualizer.tsx
@@ -64,7 +64,7 @@ export const PostVisualizer = ({ posts, session, loading, className = "" }: Post
   );
 };
 
-interface PostProps extends Pick<PostVisualizerProps, "did" | "className"> {
+export interface PostProps extends Pick<PostVisualizerProps, "did" | "className"> {
   agent: AtpAgent
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,12 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+* {
+    margin: 0;
+    padding: 0;
+    /* box-sizing: border-box; */
+}
+
 body {
   margin: 0;
   min-height: 100vh;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,3 +1,5 @@
+import { RepoEntry } from "@atcute/car";
+
 export interface BlueSkySessionData {
   accessJwt: string;
   active: boolean;
@@ -9,13 +11,13 @@ export interface BlueSkySessionData {
     service: {
       id: string;
       type: string;
-      serviceEndpoint: string
+      serviceEndpoint: string;
     }[];
     verificationMethod: {
-      controller: string,
-      id: string,
-      type: string,
-      publicKeyMultibase: string
+      controller: string;
+      id: string;
+      type: string;
+      publicKeyMultibase: string;
     }[];
   };
   email: string;
@@ -26,15 +28,83 @@ export interface BlueSkySessionData {
 }
 
 export interface BlockMap {
-  [cid: string]: string
+  [cid: string]: string;
 }
 
 export interface Repo {
   root: string;
-  blocks: BlockMap
+  blocks: BlockMap;
 }
 
 export type Post = {
   createdAt: string;
   text: string;
+  $type?: string;
+  embed?:
+    | ExternalEmbeds
+    | ImageEmbeds
+    | QuotedEmbeds;
+};
+
+/**
+ * type definition for embedded content in a Bluesky Post, mostly external links
+ * to blog posts etc
+ */
+export type ExternalEmbeds = {
+  $type: "app.bsky.embed.external";
+  external: {
+    uri: string;
+    title: string;
+    description: string;
+    thumb: {
+      $type: string;
+      mimeType: string;
+      ref: {
+        $link: string;
+      }
+    };
+  };
+};
+
+/**
+ * type definition for posts with images embedded in them
+ */
+export type ImageEmbeds = {
+  $type: "app.bsky.embed.images";
+  images: {
+    alt?: string;
+    image: {
+      $type: string;
+      mimeType: string
+      ref: {
+        $link: string;
+      };
+      size: number;
+    };
+  }[];
+};
+
+/**
+ * type definition for quoted posts on Bluesky. Quite similar to quoted replies on Twitter
+ */
+export type QuotedEmbeds = {
+  $type: "app.bsky.embed.record";
+  record: {
+    $type: "app.bsky.embed.record#viewRecord";
+    uri: string;
+    cid: string;
+    author: {
+      did: string;
+      handle: string;
+      displayName?: string;
+    };
+    // // @ts-expect-error for now, i'm entirely certain of this type
+    // value?: any;
+    // embeds?: Array<any>;
+    // indexedAt: string;
+  };
+};
+
+export interface ExtendedRepoEntry extends RepoEntry {
+  record: Post;
 }


### PR DESCRIPTION
There are a couple of lexicons on the AT protocol, and embeds is one of them. A post can have multiple embeds in it. The common one is an image embed where people make a post on Bluesky with a caption and an attached image. We have quoted posts too, and many more.

This commits introduces three of those embed $types, a record, external, and image embeds. As time goes one, we'll include more of these.